### PR TITLE
Add support for system generated values

### DIFF
--- a/modules/org.restlet.ext.odata/src/org/restlet/ext/odata/Service.java
+++ b/modules/org.restlet.ext.odata/src/org/restlet/ext/odata/Service.java
@@ -64,6 +64,7 @@ import org.restlet.engine.header.HeaderUtils;
 import org.restlet.ext.atom.Content;
 import org.restlet.ext.atom.Entry;
 import org.restlet.ext.atom.Feed;
+import org.restlet.ext.odata.annotation.SystemGenerated;
 import org.restlet.ext.odata.internal.EntryContentHandler;
 import org.restlet.ext.odata.internal.edm.AssociationEnd;
 import org.restlet.ext.odata.internal.edm.ComplexProperty;
@@ -1228,6 +1229,8 @@ public class Service {
                             AttributesImpl nullAttrs) throws SAXException {
                         for (Field field : entity.getClass()
                                 .getDeclaredFields()) {
+                        	SystemGenerated systemGeneratedAnnotation = field
+                        			.getAnnotation(SystemGenerated.class);
                             String getter = "get"
                                     + field.getName().substring(0, 1)
                                             .toUpperCase()
@@ -1235,7 +1238,7 @@ public class Service {
                             Property prop = ((Metadata) getMetadata())
                                     .getProperty(entity, field.getName());
 
-                            if (prop != null) {
+							if (prop != null && systemGeneratedAnnotation == null) {
                                 writeProperty(writer, entity, prop, getter,
                                         nullAttrs);
                             }

--- a/modules/org.restlet.ext.odata/src/org/restlet/ext/odata/internal/edm/MetadataReader.java
+++ b/modules/org.restlet.ext.odata/src/org/restlet/ext/odata/internal/edm/MetadataReader.java
@@ -578,7 +578,11 @@ public class MetadataReader extends DefaultHandler {
             if (nullable == null) {
                 property.setNullable(true);
             } else {
-                property.setNullable(Boolean.parseBoolean(nullable));
+            	boolean isNullable = Boolean.parseBoolean(nullable);
+                property.setNullable(isNullable);
+                if(!isNullable){
+                	property.getAnnotations().add("NotNull");
+                }
             }
 
             // ConcurrencyMode
@@ -595,8 +599,26 @@ public class MetadataReader extends DefaultHandler {
             if (str != null) {
                 property.setMediaType(MediaType.valueOf(str));
             }
-
-            if (getState() == State.ENTITY_TYPE) {
+            
+            String systemGenerated = attrs.getValue(
+            		XmlFormatParser.NS_DSDS_EDMANNOTATION, "IsSystemGenerated");
+            if (systemGenerated != null) {
+            	boolean isSystemGenerated = Boolean.parseBoolean(systemGenerated);
+            	if(isSystemGenerated){
+            		property.getAnnotations().add("SystemGenerated");
+                }
+            }
+            
+            if(currentEntityType!=null){
+	            List<Property> keys = currentEntityType.getKeys();
+	            for(Property prop : keys){
+	            	if(prop.getName().equalsIgnoreCase(attrs.getValue("Name"))){
+	            		property.getAnnotations().add("PrimaryKey");
+	            	}
+	            }
+            }
+            
+           if (getState() == State.ENTITY_TYPE) {
                 pushState(State.ENTITY_TYPE_PROPERTY);
                 if (property instanceof ComplexProperty) {
                     this.currentEntityType.getComplexProperties().add(

--- a/modules/org.restlet.ext.odata/src/org/restlet/ext/odata/internal/edm/Property.java
+++ b/modules/org.restlet.ext.odata/src/org/restlet/ext/odata/internal/edm/Property.java
@@ -33,6 +33,9 @@
 
 package org.restlet.ext.odata.internal.edm;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.restlet.data.MediaType;
 import org.restlet.ext.odata.internal.reflect.ReflectUtils;
 
@@ -65,6 +68,8 @@ public class Property extends NamedObject {
 
     /** The type of the property. */
     private Type type;
+    
+    private List<String> annotations = new ArrayList<String>();
 
     /**
      * Constructor.
@@ -231,4 +236,17 @@ public class Property extends NamedObject {
         this.type = type;
     }
 
+	/**
+	 * @return the annotations
+	 */
+	public List<String> getAnnotations() {
+		return annotations;
+	}
+
+	/**
+	 * @param annotations the annotations to set
+	 */
+	public void setAnnotations(List<String> annotations) {
+		this.annotations = annotations;
+	}        
 }

--- a/modules/org.restlet.ext.odata/src/org/restlet/ext/odata/internal/templates/entityType.ftl
+++ b/modules/org.restlet.ext.odata/src/org/restlet/ext/odata/internal/templates/entityType.ftl
@@ -44,6 +44,9 @@ import ${t.fullClassName};
 </#list>
 </#compress>
 
+import org.restlet.ext.odata.validation.annotation.NotNull;
+import org.restlet.ext.odata.validation.annotation.PrimaryKey;
+import org.restlet.ext.odata.validation.annotation.SystemGenerated;
 
 <#compress>
 /**
@@ -57,6 +60,9 @@ import ${t.fullClassName};
 public <#if type.abstractType>abstract </#if>class ${className} {
 
 <#list type.properties?sort_by("name") as property>
+	<#list property.annotations as annotation>
+  	@${annotation}
+  	</#list>
   <#if property.type??>
     private ${property.type.className} ${property.propertyName}<#if property.defaultValue??> = property.defaultValue</#if>;
   <#else>

--- a/modules/org.restlet.ext.odata/src/org/restlet/ext/odata/validation/annotation/NotNull.java
+++ b/modules/org.restlet.ext.odata/src/org/restlet/ext/odata/validation/annotation/NotNull.java
@@ -1,0 +1,21 @@
+
+package org.restlet.ext.odata.validation.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the annotated property can be null.
+ *
+ * @author Shantanu
+ */
+
+//Indicates that annotations with this type are to be retained by the VM so they can be read reflectively at run-time
+@Retention(RetentionPolicy.RUNTIME)
+//Indicates that this annotation type can be used to annotate only field 
+@Target(ElementType.FIELD)
+public @interface NotNull {
+	
+}

--- a/modules/org.restlet.ext.odata/src/org/restlet/ext/odata/validation/annotation/PrimaryKey.java
+++ b/modules/org.restlet.ext.odata/src/org/restlet/ext/odata/validation/annotation/PrimaryKey.java
@@ -1,0 +1,21 @@
+
+package org.restlet.ext.odata.validation.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the annotated property is Primary Key or not.
+ *
+ * @author Shantanu
+ */
+
+//Indicates that annotations with this type are to be retained by the VM so they can be read reflectively at run-time
+@Retention(RetentionPolicy.RUNTIME)
+//Indicates that this annotation type can be used to annotate only field 
+@Target(ElementType.FIELD)
+public @interface PrimaryKey {
+	
+}

--- a/modules/org.restlet.ext.odata/src/org/restlet/ext/odata/validation/annotation/SystemGenerated.java
+++ b/modules/org.restlet.ext.odata/src/org/restlet/ext/odata/validation/annotation/SystemGenerated.java
@@ -1,0 +1,21 @@
+
+package org.restlet.ext.odata.validation.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the annotated property is System Generated or not.
+ *
+ * @author Shantanu
+ */
+
+//Indicates that annotations with this type are to be retained by the VM so they can be read reflectively at run-time
+@Retention(RetentionPolicy.RUNTIME)
+//Indicates that this annotation type can be used to annotate only field 
+@Target(ElementType.FIELD)
+public @interface SystemGenerated {
+
+}


### PR DESCRIPTION
Changes to parser to skip sending system generated values. We have taken the annotation approach here, adding @SystemGenerated annotation on the field so that we can skip the same while creating POST request.
