### PR TITLE
Fixed: Prevent submitting the form for each request.

### DIFF
--- a/modules/org.restlet.ext.crypto/src/org/restlet/ext/crypto/internal/HttpNegotiateHelper.java
+++ b/modules/org.restlet.ext.crypto/src/org/restlet/ext/crypto/internal/HttpNegotiateHelper.java
@@ -99,8 +99,13 @@ public class HttpNegotiateHelper extends AuthenticatorHelper {
 			throw new RuntimeException(
 					"No challenge provided, unable to encode credentials");
 		} else {
-			// Submit the form only iff we dont have any cookies set in the request
-			if(request.getCookies().size() == 0){
+			/*
+			 * Submit the form only if we dont have any cookies set in the request.
+			 * For first /$metadata request, it wont have cookies, so it will submit the form and cookies are cached.
+			 * Double check if cached cookies really has JSESSIONID/JSESSIONIDSSO, if not then submit the form again.
+			 */
+			if(request.getCookies().size() == 0 || 
+					(request.getCookies().getFirst("JSESSIONID") == null || request.getCookies().getFirst("JSESSIONIDSSO") == null)){
 				Reference resourceRef = request.getResourceRef();
 				String relativeURL = resourceRef.toString().substring(0,
 						resourceRef.toString().lastIndexOf("/"));

--- a/modules/org.restlet.test/src/org/restlet/test/ext/odata/streamcrud/ODataCafeCrudStreamTestCase.java
+++ b/modules/org.restlet.test/src/org/restlet/test/ext/odata/streamcrud/ODataCafeCrudStreamTestCase.java
@@ -3,6 +3,7 @@ package org.restlet.test.ext.odata.streamcrud;
 
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 
 import junit.framework.Assert;
@@ -82,7 +83,12 @@ public class ODataCafeCrudStreamTestCase extends RestletTestCase {
         assertEquals(111111, cafe1.getZipCode());
         attachment = cafe1.getAttachment();  
         assertEquals(contentType, attachment.getContentType());
-        inputStream=  attachment.getInputStream(service);
+        try {
+			inputStream=  attachment.getInputStream(service);
+		} catch (IOException e) {
+			e.printStackTrace();
+			Assert.fail();
+		}
         assertNotNull(inputStream);   
         
        
@@ -115,7 +121,12 @@ public class ODataCafeCrudStreamTestCase extends RestletTestCase {
 		assertEquals(111111, cafe2.getZipCode());
 		attachment = cafe2.getAttachment();
 		assertEquals(contentType, attachment.getContentType());
-		inputStream = attachment.getInputStream(service);
+		try {
+			inputStream = attachment.getInputStream(service);
+		} catch (IOException e) {
+			e.printStackTrace();
+			Assert.fail();
+		}
 		assertNotNull(inputStream);
 
 		// Delete


### PR DESCRIPTION
Created a class variable in Service.java which will hold the cookies when $metadata request is handled using HTTP Negotiate Helper for form based authentication. 
For each subsequent requests after that, we prefill the cookies with these cached cookie list (which is checked before submitting form in NegotiateHelper).

Also fixed couple of warnings/errors in one test class.
