### PR TITLE
1. Modified build.xml to refer antlib.xml instead of antcontrib.properties

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -78,7 +78,7 @@
 	<!-- =================== -->
 
 	<!-- Ant Contrib -->
-	<taskdef resource="net/sf/antcontrib/antcontrib.properties">
+	<taskdef resource="net/sf/antcontrib/antlib.xml">
 		<classpath>
 			<fileset dir="${tools}/ant-contrib" includes="**/*.jar" />
 		</classpath>

--- a/modules/org.restlet.ext.odata/src/org/restlet/ext/odata/Query.java
+++ b/modules/org.restlet.ext.odata/src/org/restlet/ext/odata/Query.java
@@ -33,7 +33,6 @@
 
 package org.restlet.ext.odata;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -270,6 +269,7 @@ public class Query<T> implements Iterable<T> {
                 (Class<T>) this.entityClass);
         try {
 			value = URLEncoder.encode(value,CharacterSet.UTF_8.getName());
+			value.replace("%2F", "/");// don't encode slash
 		} catch (Exception e) {
 			getLogger().warning(
 					"Unable to encode query string : "+ e.getMessage());

--- a/modules/org.restlet.test/src/org/restlet/test/ext/odata/complexcrud/ODataCafeCrudTestCase.java
+++ b/modules/org.restlet.test/src/org/restlet/test/ext/odata/complexcrud/ODataCafeCrudTestCase.java
@@ -47,6 +47,7 @@ public class ODataCafeCrudTestCase extends RestletTestCase {
 	protected void tearDown() throws Exception {
 		component.stop();
 		component = null;
+		service = null;
 		super.tearDown();
 	}
 

--- a/modules/org.restlet.test/src/org/restlet/test/ext/odata/crud/ODataSimpleCafeCrudTestCase.java
+++ b/modules/org.restlet.test/src/org/restlet/test/ext/odata/crud/ODataSimpleCafeCrudTestCase.java
@@ -41,6 +41,7 @@ public class ODataSimpleCafeCrudTestCase extends RestletTestCase {
 	protected void tearDown() throws Exception {
 		component.stop();
 		component = null;
+		service = null;
 		super.tearDown();
 	}
 

--- a/modules/org.restlet.test/src/org/restlet/test/ext/odata/deepexpand/ODataDeepExpandTestCase.java
+++ b/modules/org.restlet.test/src/org/restlet/test/ext/odata/deepexpand/ODataDeepExpandTestCase.java
@@ -43,6 +43,7 @@ public class ODataDeepExpandTestCase extends RestletTestCase {
     protected void tearDown() throws Exception {
         component.stop();
         component = null;
+        service = null;
         super.tearDown();
     }
 

--- a/modules/org.restlet.test/src/org/restlet/test/ext/odata/streamcrud/ODataCafeCrudStreamTestCase.java
+++ b/modules/org.restlet.test/src/org/restlet/test/ext/odata/streamcrud/ODataCafeCrudStreamTestCase.java
@@ -44,6 +44,7 @@ public class ODataCafeCrudStreamTestCase extends RestletTestCase {
     protected void tearDown() throws Exception {
         component.stop();
         component = null;
+        service = null;
         super.tearDown();
     }
 


### PR DESCRIPTION
so that vanilla ant-contrib jar can be used instead of modified one found in build/tools/ant-contrib.
1. Stop encoding slash character when adding query parameters.
2. Also fixed some minor issues with test cases.
